### PR TITLE
fix: forward parent origin to embed urls

### DIFF
--- a/src/playground.ts
+++ b/src/playground.ts
@@ -61,9 +61,9 @@ document.getElementById("start")?.addEventListener("click", async () => {
     },
   });
 
-  // await moneyHash.renderForm({ selector: "#app", intentId: paymentIntentId });
-  const intentDetails = await moneyHash.getIntentDetails(paymentIntentId);
-  console.log(intentDetails);
+  await moneyHash.renderForm({ selector: "#app", intentId: paymentIntentId });
+  // const intentDetails = await moneyHash.getIntentDetails(paymentIntentId);
+  // console.log(intentDetails);
 
   // const intentMethods = await moneyHash.getIntentMethods(paymentIntentId);
   // console.log(intentMethods);

--- a/src/sdkApiHandler.ts
+++ b/src/sdkApiHandler.ts
@@ -16,9 +16,15 @@ export default class SDKApiHandler {
   private initSDKCommunicationIframe() {
     if (document.getElementById("moneyhash-headless-sdk")) return;
 
+    const url = new URL(
+      `${import.meta.env.VITE_IFRAME_URL}/embed/headless-sdk`,
+    );
+    url.searchParams.set("sdk", "true");
+    url.searchParams.set("parent", window.location.origin);
+
     const iframe = document.createElement("iframe");
     iframe.id = "moneyhash-headless-sdk";
-    iframe.src = `${import.meta.env.VITE_IFRAME_URL}/embed/headless-sdk`;
+    iframe.src = url.toString();
     iframe.hidden = true;
     document.body.appendChild(iframe);
 

--- a/src/sdkEmbed.ts
+++ b/src/sdkEmbed.ts
@@ -56,16 +56,18 @@ export default class SDKEmbed<TType extends IntentType> {
     // cleanup previous listeners
     this.messagingService?.abortService();
 
-    this.iframe = document.createElement("iframe");
     const url = new URL(
       `${import.meta.env.VITE_IFRAME_URL}/embed/${
         this.options.type
-      }/${intentId}?sdk=true`,
+      }/${intentId}`,
     );
+    url.searchParams.set("sdk", "true");
+    url.searchParams.set("parent", window.location.origin);
 
     const lang = this.options.locale?.split("-")[0];
     if (lang) url.searchParams.set("lang", lang);
 
+    this.iframe = document.createElement("iframe");
     this.iframe.src = url.toString();
     this.iframe.style.height = "100%";
     this.iframe.style.width = "100%";


### PR DESCRIPTION
Since the Referrer-Policy: no-referrer header will instruct the user agent not to send a Referer header at all,

`document.referer` will be empty & we don't have a reliable way to get the parent app URL other than that.

Suggestion: 
- Make the parent app forwarding its origin through query params & read it in the checkout app