### PR TITLE
feat: add optional merchantIdentifier param to validateApplePayMerchantSession

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneyhash/js-sdk",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "MoneyHash JavaScript SDK",
   "type": "module",
   "files": [

--- a/src/headlessMoneyHash.ts
+++ b/src/headlessMoneyHash.ts
@@ -380,14 +380,17 @@ export default class MoneyHashHeadless<TType extends IntentType> {
    *
    * @param methodId - Apple pay method id from nativePayData
    * @param validationURL - Apple pay validation url you get from `ApplePaySession.onvalidatemerchant`
+   * @param merchantIdentifier - (Optional) For payment platforms registering merchants through the {@link https://developer.apple.com/documentation/ApplePayWebMerchantRegistrationAPI Apple Pay Web Merchant Registration API}, this should be the partnerInternalMerchantIdentifier defined for each registered merchant.
    * @returns
    */
   async validateApplePayMerchantSession({
     methodId,
     validationUrl,
+    merchantIdentifier,
   }: {
     methodId: string;
     validationUrl: string;
+    merchantIdentifier?: string;
   }) {
     return this.sdkApiHandler.request<ApplePayMerchantSession>({
       api: "sdk:applePaySession",
@@ -395,6 +398,7 @@ export default class MoneyHashHeadless<TType extends IntentType> {
         methodId,
         validationUrl,
         parentOrigin: window.location.origin,
+        merchantIdentifier,
       },
     });
   }


### PR DESCRIPTION
For merchants using the Apple Pay Web Merchant Registration API, this passes
the `partnerInternalMerchantIdentifier` to the session validation request.
